### PR TITLE
Fix headshots handling & Improve config parsing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/scripting/quakesounds_hl2dm.sp
+++ b/scripting/quakesounds_hl2dm.sp
@@ -286,14 +286,21 @@ public LoadSounds()
 
 					if (buffer[0] != '\0')
 					{
-						LoadSoundSets(kvQSL, typeKey, StringToInt(buffer));
+						LoadSoundSets(kvQSL, typeKey, buffer);
 					}
 				}
 				while(KvGotoNextKey(kvQSL));
 			}
 			else
 			{
-				LoadSoundSets(kvQSL, typeKey, KvGetNum(kvQSL, "kills"));
+				KvGetString(kvQSL, "kills", buffer, sizeof(buffer));
+				decl String:settingKills[MAX_NUM_KILLS][8];
+
+				for (new i = ExplodeString(buffer, ",", settingKills, sizeof(settingKills), sizeof(settingKills[]));
+					--i >= 0;)
+				{
+					LoadSoundSets(kvQSL, typeKey, settingKills[i]);
+				}
 			}
 		}
 	}
@@ -301,9 +308,9 @@ public LoadSounds()
 	CloseHandle(kvQSL);
 }
 
-LoadSoundSets(Handle:kvQSL, typeKey, settingKills)
+LoadSoundSets(Handle:kvQSL, typeKey, String:settingKillsBuf[])
 {
-	new tempConfig = KvGetNum(kvQSL, "config", 9);
+	new settingKills = StringToInt(settingKillsBuf), tempConfig = KvGetNum(kvQSL, "config", 9);
 
 	if (settingKills > -1 && settingKills < MAX_NUM_KILLS && tempConfig > 0)
 	{

--- a/scripting/quakesounds_hl2dm.sp
+++ b/scripting/quakesounds_hl2dm.sp
@@ -187,7 +187,7 @@ public QuakePrefSelected(client, CookieMenuAction:action, any:info, String:buffe
 {
 	if (action == CookieMenuAction_SelectOption)
 	{
-		ShowQuakeMenu(client);
+		ShowQuakeMenu(client, true);
 	}
 }
 
@@ -798,8 +798,15 @@ public MenuHandlerQuake(Handle:menu, MenuAction:action, param1, param2)
 		IntToString(soundPreference[param1], buffer, 5);
 		SetClientCookie(param1, cookieSoundPref, buffer);
 		
-		MenuQuake(param1, 0);
-	} 
+		ShowQuakeMenu(param1, GetMenuExitBackButton(menu));
+	}
+	else if (action == MenuAction_Cancel)
+	{
+		if (param2 == MenuCancel_ExitBack)
+		{
+			ShowCookieMenu(param1);
+		}
+	}
 	else if(action == MenuAction_End)
 	{
 		CloseHandle(menu);
@@ -810,13 +817,14 @@ public MenuHandlerQuake(Handle:menu, MenuAction:action, param1, param2)
 public Action:MenuQuake(client, args)
 {
 	decho(0,"Got MenuQuake");
-	ShowQuakeMenu(client);
+	ShowQuakeMenu(client, false);
 	return Plugin_Handled;
 }
 
-ShowQuakeMenu(client)
+ShowQuakeMenu(client, bool:exitBackButton)
 {
 	new Handle:menu = CreateMenu(MenuHandlerQuake);
+	SetMenuExitBackButton(menu, exitBackButton);
 	decl String:buffer[100];
 	
 	Format(buffer, sizeof(buffer), "%T", "quake menu", client);
@@ -875,4 +883,3 @@ stock decho(dest, const String:myString[], any:...)
 	}
 	
 }
-

--- a/scripting/quakesounds_hl2dm.sp
+++ b/scripting/quakesounds_hl2dm.sp
@@ -449,7 +449,7 @@ public OnClientPutInServer(client)
 		// Make the announcement in 30 seconds unless announcements are turned off
 		if(GetConVarBool(cvarAnnounce))
 		{
-			CreateTimer(30.0, TimerAnnounce, client);
+			CreateTimer(30.0, TimerAnnounce, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
 		}
 	
 		// Play event sound
@@ -478,9 +478,11 @@ public OnClientPutInServer(client)
 	}
 }
 
-public Action:TimerAnnounce(Handle:timer, any:client)
+public Action:TimerAnnounce(Handle:timer, any:userId)
 {
-	if(IsClientInGame(client))
+	new client = GetClientOfUserId(userId);
+
+	if (client > 0)
 	{
 		PrintToChat(client, "%t", "announce message");
 	}

--- a/scripting/quakesounds_hl2dm.sp
+++ b/scripting/quakesounds_hl2dm.sp
@@ -875,4 +875,3 @@ stock decho(dest, const String:myString[], any:...)
 	}
 	
 }
-

--- a/scripting/quakesounds_hl2dm.sp
+++ b/scripting/quakesounds_hl2dm.sp
@@ -729,15 +729,20 @@ public PrintQuakeText(soundKey, killsValue, attackerClient, victimClient)
 	}
 	
 	decl String:translationName[65];
-	if(killsValue>0)
+	new len = strcopy(translationName, sizeof(translationName), typeNames[soundKey]);
+
+	if (killsValue > 0)
 	{
-		Format(translationName, 65, "%s %i", typeNames[soundKey], killsValue);
+		FormatEx(translationName[len], sizeof(translationName) - len, " %i", killsValue);
+
+#if (SOURCEMOD_V_MINOR > 6)
+		if (!TranslationPhraseExists(translationName))
+		{
+			translationName[len] = '\0';
+		}
+#endif // (SOURCEMOD_V_MAJOR > 6)
 	}
-	else
-	{
-		Format(translationName, 65, "%s", typeNames[soundKey]);
-	}
-	
+
 	new config = settingConfig[soundKey][killsValue];
 
 	if(config & 8) 

--- a/scripting/quakesounds_hl2dm.sp
+++ b/scripting/quakesounds_hl2dm.sp
@@ -733,7 +733,7 @@ PlaySoundFile(client, soundKey, killsValue, setsFileIndices[MAX_NUM_SETS] = { -1
 		}
 
 		EmitSoundToClient(client, soundsFiles[setsFileIndices[soundPreference[client]]],
-			_, _, _, _, GetConVarFloat(cvarVolume));
+			_, _, _, SND_STOP, GetConVarFloat(cvarVolume));
 	}
 }
 

--- a/translations/plugin.quakesounds.txt
+++ b/translations/plugin.quakesounds.txt
@@ -1,6 +1,6 @@
 "Phrases"
 {
-	"headshot 1"
+	"headshot"
 	{
 		"#format"	"{1:s},{2:s}"
 		"en"		"{1} Headshot"


### PR DESCRIPTION
Hi,

Last weeks I decided to make certain changes I came with. I'm going to describe them in enough detail, also for any server admins to understand. These include:

- **Fix headshot issues**:
  - Fix headshot events being triggered when killing with non-hitscan weapons, if the last hit to the victim done by a hitscan weapon was in the head
  - Reset client's HS streak count when they die. Triggering HS events tied to > 0 kill streaks not achieved within the same life felt too weak. I went to investigate if this was a common convention in Quake sounds plugins and, for instance, [Quake sounds v3](https://forums.alliedmods.net/showthread.php?p=2019601) also applies new behaviour.
- **Add** countless **fallback** for **counted kill phrases**. If someone wants to set e.g. headshot events for every kill, now they don't need to go and rename the `"headshot 1"` phrase to `"headshot 0"` anymore. See the related commit for more details.
- **Support randomized sounds**. Admins can now configure multiple sounds to play one randomly each event! (per sound set). To stay consistent, during an event action, the logic will carry the randomized sound for each sound set from the time it's demanded (by the first applicable client) to the rest of the clients with the same sound set. I.e. target clients will play same temporary randomized sound between equal sets.
- **Support multiple kills config values** on same line. Write less, do more. If you want to share possible settings for different kill streak counts, you can do easily now (I guess the best fitting event type is headshot, anyways).

Self-explanatory samples from my server's config:

- Randomized sounds:

Instead of assigning a sound directly as a value for the sound set (e.g. **"standard" "file.mp3"**), you need to organize the keys in the following way, listing each possible random sound as a subkey of the sound set:

```
"Grenade" // The event type
{
	"0" // The kill count
	{
		"standard" // The sound set
		{
			"1" "kdnnuevo/boombombazo.mp3"
			"2" "kolokonklan/xgrenadex.mp3"
		}
	}
}
```

Of course, the original one-liner format for a single assigned sound is still supported.
**Important**: the randomized setups will only work when a kill count key (`"0"` in the example) surrounds the sound set key. Otherwise the event will be set incorrectly.

- One-liner multiple kill streaks specification:

```
"Headshot"
{
	"standard"	"kdnnuevo/quake/boomheadshot.mp3"
	"kills"		"0,3,5"
}
```

In the context of the proposed changes in the PR, this setup means: play the specified HS sound when applicable at kill streaks 3 & 5 (with the unique `"headshot 3`" and `"headshot 5"` existing phrases each), and for every other kill streak with the unique `"headshot"` phrase (originally the `"headshot 1"` one).

Finally, the changes are already well tested from my server. If you want to see them in action, you can [add me](https://s.team/p/cvc-jfcb/pmkbkjrh) in Steam. I hope you like the changes!

Thank you.